### PR TITLE
Resolve symlinks before running p4 commands on a file

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -229,7 +229,7 @@ def AppendToChangelistDescription(changelist, input):
     return 1, result
 
 def PerforceCommandOnFile(in_command, in_folder, in_filename):
-    command = ConstructCommand('p4 {0} "{1}"'.format(in_command, in_filename))
+    command = ConstructCommand('p4 {0} "{1}"'.format(in_command, os.path.realpath(in_filename)))
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=global_folder, shell=True)
     result, err = p.communicate()
     result = result.decode("utf-8")


### PR DESCRIPTION
While this should really happen inside the p4 executable, I don't have the source code for that. We have symlinks from one portion of the tree to another, and this lets us edit in either location and successfully checkout the file in p4.
