### PR TITLE
Changed "source" to "."

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -37,9 +37,9 @@ def ConstructCommand(in_command):
     p4Env = perforce_settings.get('perforce_p4env')
     command = ''
     if(p4Env and p4Env != ''):
-        command = 'source {0} && '.format(p4Env)
+        command = '. {0} && '.format(p4Env)
     elif(sublime.platform() == "osx"):
-        command = 'source ~/.bash_profile && '
+        command = '. ~/.bash_profile && '
     # Revert change until threading is fixed
     # command = getPerforceConfigFromPreferences(command)
     command += in_command


### PR DESCRIPTION
The default Ubuntu shell is "dash" which doesn't support "source". It does support "." which is POSIX standard.

http://pubs.opengroup.org/onlinepubs/009695399/utilities/dot.html