### PR TITLE
Extended Graphical Diff Functionality

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -27,11 +27,11 @@
             },
             {
                 "command": "perforce_create_changelist",
-                "caption": "Create Changelist" 
+                "caption": "Create Changelist"
             },
             {
                 "command": "perforce_delete",
-                "caption": "Delete" 
+                "caption": "Delete"
             },
             {
                 "command": "perforce_diff",
@@ -43,21 +43,41 @@
                 [
                     {
                         "command": "perforce_graphical_diff_with_depot",
-                        "caption": "Diff"
+                        "caption": "Diff Against Have Revision",
+                        "args":
+                        {
+                            "target_revision": "have"
+                        }
+                    },
+                    {
+                        "command": "perforce_graphical_diff_with_depot",
+                        "caption": "Diff Against Latest Revision",
+                        "args":
+                        {
+                            "target_revision": "head"
+                        }
+                    },
+                    {
+                        "command": "perforce_graphical_diff_with_depot",
+                        "caption": "Diff Against Specific Revision",
+                        "args":
+                        {
+                            "target_revision": "specific_revision"
+                        }
                     },
                     {
                         "command": "perforce_select_graphical_diff_application",
                         "caption": "Select Diff Application"
                     }
                 ]
-            },            
+            },
             {
                 "command": "perforce_list_checked_out_files",
                 "caption": "List Checked Out Files"
             },
             {
                 "command": "perforce_move_current_file_to_changelist",
-                "caption": "Move Current File To Changelist"                        
+                "caption": "Move Current File To Changelist"
             },
             {
                 "command": "perforce_rename",
@@ -84,6 +104,10 @@
                         "caption": "Unshelve Changelist"
                     }
                 ]
+            },
+            {
+                "command": "perforce_show_revisions_list",
+                "caption": "Show Revisions List"
             },
             {
                 "command": "perforce_logout",

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -28,8 +28,28 @@
         "command": "perforce_diff"
     },
     {
-        "caption": "Perforce: Graphical Diff with Depot",
-        "command": "perforce_graphical_diff_with_depot"
+        "caption": "Perforce: Diff Against Have Revision",
+        "command": "perforce_graphical_diff_with_depot",
+        "args":
+        {
+            "target_revision": "have"
+        }
+    },
+    {
+        "caption": "Perforce: Diff Against Latest Revision",
+        "command": "perforce_graphical_diff_with_depot",
+        "args":
+        {
+            "target_revision": "head"
+        }
+    },
+    {
+        "caption": "Perforce: Diff Against Specific Revision",
+        "command": "perforce_graphical_diff_with_depot",
+        "args":
+        {
+            "target_revision": "specific_revision"
+        }
     },
     {
         "caption": "Perforce: Select Graphical Diff Application",
@@ -66,5 +86,9 @@
     {
         "caption": "Perforce: Unshelve Changelist",
         "command": "perforce_unshelve_cl"
+    },
+    {
+        "caption": "Perforce: Show Revisions List",
+        "command": "perforce_show_revisions_list"
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -29,11 +29,11 @@
                     },
                     {
                         "command": "perforce_create_changelist",
-                        "caption": "Create Changelist" 
+                        "caption": "Create Changelist"
                     },
                     {
                         "command": "perforce_delete",
-                        "caption": "Delete" 
+                        "caption": "Delete"
                     },
                     {
                         "command": "perforce_diff",
@@ -45,7 +45,27 @@
                         [
                             {
                                 "command": "perforce_graphical_diff_with_depot",
-                                "caption": "Diff"
+                                "caption": "Diff Against Have Revision",
+                                "args":
+                                {
+                                    "target_revision": "have"
+                                }
+                            },
+                            {
+                                "command": "perforce_graphical_diff_with_depot",
+                                "caption": "Diff Against Latest Revision",
+                                "args":
+                                {
+                                    "target_revision": "head"
+                                }
+                            },
+                            {
+                                "command": "perforce_graphical_diff_with_depot",
+                                "caption": "Diff Against Specific Revision",
+                                "args":
+                                {
+                                    "target_revision": "specific_revision"
+                                }
                             },
                             {
                                 "command": "perforce_select_graphical_diff_application",
@@ -59,7 +79,7 @@
                     },
                     {
                         "command": "perforce_move_current_file_to_changelist",
-                        "caption": "Move Current File To Changelist"                        
+                        "caption": "Move Current File To Changelist"
                     },
                     {
                         "command": "perforce_rename",
@@ -86,6 +106,10 @@
                                 "caption": "Unhelve Changelist"
                             }
                          ]
+                    },
+                    {
+                        "command": "perforce_show_revisions_list",
+                        "caption": "Show Revisions List"
                     },
                     {
                         "command": "perforce_logout",

--- a/Perforce.sublime-settings
+++ b/Perforce.sublime-settings
@@ -6,6 +6,6 @@
 	"perforce_warnings_enabled": true, // will output messages when warnings happen
 	"perforce_end_line_separator": "\n", // used to reconstruct the depot file after breaking it up to remove the first line
 	"perforce_log_warnings_to_status": true, // used to redirect logs to the status bar instead. The standard output is too big for the line (can be multi-line with the raw output of p4)
-	"perforce_default_graphical_diff_command": "p4diff \"%depotfile_path\" \"%file_path\" -l \"%file_name in depot\" -e -1 4" // used only if Select Graphical Diff Application is not called
+	"perforce_default_graphical_diff_command": "p4merge -nl \"%depotfile_name\" \"%depotfile_path\" \"%file_path\" ",  // used only if Select Graphical Diff Application is not called
     // "perforce_p4env": "~/.p4env", // optional environent file to source rather than ~/.bash_profile
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Supports auto add and checkout with commands to add, checkout, delete, diff, ren
 The preferred method is to use the [Sublime Package Manager](http://wbond.net/sublime_packages/package_control). Alternatively, the files can be obtained on github:
 
     $ https://github.com/ericmartel/Sublime-Text-3-Perforce-Plugin
-    
+
 ### Install Note
 
 If the plugin is unable to use your p4, it is possible that it keeps reporting that the file is not under the client root.  User @JLoppert suggests creating a symlink under OSX/Linux


### PR DESCRIPTION
Changes:
* Graphical diff can now diff the current file against a "have" revision,
 "head" revision, or a user-specified revision of the file.
* Added Show Revisions List command, which came as a biproduct of extending
 graphical diff to include user-specified revisions. Revisions are shown
 in quick find.
* Updated the default graphical diff command to use p4merge instead of
p4diff
* Added confirmation dialogs for Checkout and Revert.