### PR TITLE
Add perforce_p4path to settings to specify path to p4 executable

### DIFF
--- a/Perforce.py
+++ b/Perforce.py
@@ -35,11 +35,14 @@ perforceplugin_dir = os.getcwd()
 def ConstructCommand(in_command):
     perforce_settings = sublime.load_settings('Perforce.sublime-settings')
     p4Env = perforce_settings.get('perforce_p4env')
+    p4Path = perforce_settings.get('perforce_p4path')
+    if ( p4Path == None or p4Path == '' ):
+        p4Path = ''
     command = ''
     if(p4Env and p4Env != ''):
-        command = '. {0} && '.format(p4Env)
+        command = '. {0} && {1}'.format(p4Env, p4Path)
     elif(sublime.platform() == "osx"):
-        command = '. ~/.bash_profile && '
+        command = '. ~/.bash_profile && {0}'.format(p4Path)
     # Revert change until threading is fixed
     # command = getPerforceConfigFromPreferences(command)
     command += in_command

--- a/Perforce.sublime-settings
+++ b/Perforce.sublime-settings
@@ -6,6 +6,7 @@
 	"perforce_warnings_enabled": true, // will output messages when warnings happen
 	"perforce_end_line_separator": "\n", // used to reconstruct the depot file after breaking it up to remove the first line
 	"perforce_log_warnings_to_status": true, // used to redirect logs to the status bar instead. The standard output is too big for the line (can be multi-line with the raw output of p4)
-	"perforce_default_graphical_diff_command": "p4diff \"%depotfile_path\" \"%file_path\" -l \"%file_name in depot\" -e -1 4" // used only if Select Graphical Diff Application is not called
-    // "perforce_p4env": "~/.p4env", // optional environent file to source rather than ~/.bash_profile
+	"perforce_default_graphical_diff_command": "p4diff \"%depotfile_path\" \"%file_path\" -l \"%file_name in depot\" -e -1 4", // used only if Select Graphical Diff Application is not called
+	// "perforce_p4env": "~/.p4env", // optional environent file to source rather than ~/.bash_profile
+	//"perforce_p4path": "/usr/local/bin/"		// optional path for p4 if symlink not available (e.g. OSX El Capitan cannot write to /usr/bin/). 
 }


### PR DESCRIPTION
On OSX El Capitan you can no longer write to /usr/bin/ so the suggested symlink method is not available. I thought it might be useful to specify the path to p4 in the settings file instead (e.g. /usr/local/bin/p4)